### PR TITLE
F9 Keymapping entfernt

### DIFF
--- a/intraTab/client/main.lua
+++ b/intraTab/client/main.lua
@@ -543,7 +543,7 @@ RegisterCommand('intrarptest', function()
 end, false)
 
 -- Key mapping
-RegisterKeyMapping(Config.eNOTF.Command, 'Open eNOTF Tablet', 'keyboard', Config.eNOTF.OpenKey or 'F9')
+RegisterKeyMapping(Config.eNOTF.Command, 'Open eNOTF Tablet', 'keyboard', Config.eNOTF.OpenKey)
 if Config.FireTab.OpenKey then
     RegisterKeyMapping(Config.FireTab.Command, 'Open FireTab', 'keyboard', Config.FireTab.OpenKey)
 end

--- a/intraTab/config.lua
+++ b/intraTab/config.lua
@@ -24,7 +24,7 @@ Config.Debug = false
 Config.eNOTF = {
     Enabled = true,
     Command = 'enotf',
-    OpenKey = 'F9',  -- Taste zum Öffnen (eNOTF-spezifisch)
+    OpenKey = 'F9',  -- Optional: Taste, oder nil für keine
     AllowedJobs = {
         'police',
         'ambulance',
@@ -53,7 +53,7 @@ Config.eNOTF = {
 Config.FireTab = {
     Enabled = true,
     Command = 'firetab',
-    OpenKey = nil,  -- Optional: Separate Taste, oder nil für keine
+    OpenKey = nil,  -- Optional: Taste, oder nil für keine
     AllowedJobs = {
         'firedepartment',
         'admin'


### PR DESCRIPTION
Standard belegung bei F9 ist die Leitstelle von EMD